### PR TITLE
[Remove] 商品編集画面 記述を一部削除

### DIFF
--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -32,7 +32,7 @@
   <div class="form-group row">
     <label class="col-md-2 offset-md-2">販売価格</label>
     <div class="col-md-4">
-     <%= f.number_field :tax_exclusive_price.to_s(:delimited), style: "width:76%;" %>円
+     <%= f.number_field :tax_exclusive_price, style: "width:76%;" %>円
     </div>
   </div>
   <div class="form-group row">


### PR DESCRIPTION
管理者側の商品編集画面
　三桁ごとにカンマを追加する記述を削除